### PR TITLE
Add linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,122 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Debug
+          ACTIONS_RUNNER_DEBUG: false
+          # Options
+          DEFAULT_BRANCH: main
+          LINTER_RULES_PATH: /
+          DOCKERFILE_HADOLINT_FILE_NAME: .hadolint.yaml
+          # Enabled validation
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITLEAKS: true
+          VALIDATE_SHELL_SHFMT: true
+          # Disabled validation
+          # VALIDATE_ANSIBLE: false
+          # VALIDATE_ARM: false
+          # VALIDATE_CLANG_FORMAT: false
+          # VALIDATE_CLOJURE: false
+          # VALIDATE_CLOUDFORMATION: false
+          # VALIDATE_COFFEESCRIPT: false
+          # VALIDATE_CPP: false
+          # VALIDATE_CSHARP: false
+          # VALIDATE_CSS: false
+          # VALIDATE_DART: false
+          # VALIDATE_DOCKERFILE: true
+          # VALIDATE_EDITORCONFIG: false
+          # VALIDATE_ENV: false
+          # VALIDATE_GHERKIN: false
+          # VALIDATE_GO: false
+          # VALIDATE_GOOGLE_JAVA_FORMAT: false
+          # VALIDATE_GROOVY: false
+          # VALIDATE_HTML: false
+          # VALIDATE_JAVA: false
+          # VALIDATE_JAVASCRIPT_ES: false
+          # VALIDATE_JAVASCRIPT_STANDARD: false
+          # VALIDATE_JSCPD: false
+          # VALIDATE_JSON: false
+          # VALIDATE_JSX: false
+          # VALIDATE_KOTLIN: false
+          # VALIDATE_KUBERNETES_KUBEVAL: false
+          # VALIDATE_LATEX: false
+          # VALIDATE_LUA: false
+          # VALIDATE_MARKDOWN: false
+          # VALIDATE_NATURAL_LANGUAGE: false
+          # VALIDATE_OPENAPI: false
+          # VALIDATE_PERL: false
+          # VALIDATE_PHP_BUILTIN: false
+          # VALIDATE_PHP_PHPCS: false
+          # VALIDATE_PHP_PHPSTAN: false
+          # VALIDATE_PHP_PSALM: false
+          # VALIDATE_PHP: false
+          # VALIDATE_POWERSHELL: false
+          # VALIDATE_PROTOBUF: false
+          # VALIDATE_PYTHON_BLACK: false
+          # VALIDATE_PYTHON_FLAKE8: false
+          # VALIDATE_PYTHON_ISORT: false
+          # VALIDATE_PYTHON_MYPY: false
+          # VALIDATE_PYTHON_PYLINT: false
+          # VALIDATE_PYTHON: false
+          # VALIDATE_R: false
+          # VALIDATE_RAKU: false
+          # VALIDATE_RUBY: false
+          # VALIDATE_RUST_2015: false
+          # VALIDATE_RUST_2018: false
+          # VALIDATE_RUST_CLIPPY: false
+          # VALIDATE_SCALAFMT_LINT: false
+          # VALIDATE_SNAKEMAKE_LINT: false
+          # VALIDATE_SNAKEMAKE_SNAKEFMT: false
+          # VALIDATE_SQL: false
+          # VALIDATE_SQLFLUFF: false
+          # VALIDATE_STATES: false
+          # VALIDATE_TEKTON: false
+          # VALIDATE_TERRAFORM_TERRASCAN: false
+          # VALIDATE_TERRAFORM_TFLINT: false
+          # VALIDATE_TERRAGRUNT: false
+          # VALIDATE_TSX: false
+          # VALIDATE_TYPESCRIPT_ES: false
+          # VALIDATE_TYPESCRIPT_STANDARD: false
+          # VALIDATE_XML: false
+          # VALIDATE_YAML: false

--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -1,0 +1,120 @@
+name: publish
+
+on:
+
+  push:
+    branches:
+      # pushes to main will trigger an EDGE image
+      - main
+
+  release:
+    # The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger.
+    # If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.
+    types:
+      - published
+
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # at 03:00 on each Tuesday attempt to build a new image
+    - cron:  '0 3 * * 2'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # when permissions are defined only those that are explicitly set will be enabled
+      # this workflow job currently only requires reading contents and writing packages.
+      # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
+      contents: read
+      packages: write
+
+    steps:
+      - name: Validate secret defined
+        id: from_secrets
+        run: |
+          github_container_push="true";
+          dockerhub_token_exists="false";
+          dockerhub_username_exists="false";
+          dockerhub_namespace_exists="false";
+          [[ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]] && dockerhub_token_exists="true";
+          [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]] && dockerhub_username_exists="true";
+          [[ -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]] && dockerhub_namespace_exists="true";
+          [[ "true" = "${{ secrets.GITHUB_CONTAINER_PUSH_DISABLED }}" ]] && github_container_push="false";
+          echo "::set-output name=dockerhub_token_exists::${dockerhub_token_exists}";
+          echo "::set-output name=dockerhub_username_exists::${dockerhub_username_exists}";
+          echo "::set-output name=dockerhub_namespace_exists::${dockerhub_namespace_exists}";
+          echo "::set-output name=github_container_push::${github_container_push}";
+      - name: Generate container image names
+        id: generate_image_names
+        run: |
+          repository_name="$(basename "${GITHUB_REPOSITORY}")";
+          images=();
+          if [[ "${{ steps.from_secrets.outputs.github_container_push }}" = "true" ]];
+          then
+            # set GITHUB_CONTAINER_PUSH_DISABLED to a value of true to disable pushing to github container registry
+            images+=("ghcr.io/${GITHUB_REPOSITORY}");
+          fi
+          if [[ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]] && [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]] && [[ -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]];
+          then
+            # dockerhub repository should be the same as the github repository name, within the dockerhub namespace (organization or personal)
+            images+=("${{ secrets.DOCKERHUB_NAMESPACE }}/${repository_name}");
+          fi
+          # join the array for Docker meta job to produce image tags
+          # https://github.com/crazy-max/ghaction-docker-meta#inputs
+          echo "::set-output name=images::$(IFS=,; echo "${images[*]}")";
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ steps.generate_image_names.outputs.images }}
+          labels: |
+            maintainer=arledesma
+            org.opencontainers.image.title=Amplify Build Image
+            org.opencontainers.image.description=Build Image for AWS Amplify
+            org.opencontainers.image.base.name=amazonlinux:2
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=edge,branch=main
+            type=ref,event=branch
+            type=ref,event=push
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        # conditions do not have direct access to github secrets so we check the output of the step from_secrets
+        if: ${{ steps.from_secrets.outputs.dockerhub_namespace_exists == 'true' && steps.from_secrets.outputs.dockerhub_token_exists == 'true' && steps.from_secrets.outputs.dockerhub_username_exists == 'true' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: ${{ steps.from_secrets.outputs.github_container_push == 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./compose/django/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: ${{ contains(fromJson('["push", "schedule"]'), github.event_name) }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+ignored:
+  - DL3033 # Not limiting to a specific package version - we want the current packages
+  - DL4006 # SHELL uses -o pipefail
+  - SC2039 # SHELL is bash, not sh - we have 'source'
+  - DL3003 # No need to use WORKDIR for temporary cd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.8.0
+    hooks:
+      - id: hadolint-docker

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![GitHub Super-Linter](https://github.com/arledesma/amplify-build-image/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)


### PR DESCRIPTION
This introduces linting for the current codebase, providing required styles and basic security validation. 

The primary linting is performed by [hadolint](https://github.com/hadolint/hadolint) using both GitHub's [super-linter](https://github.com/github/super-linter) and the hadolint [integrations](https://github.com/hadolint/hadolint#integrations) [pre-commit hook](https://github.com/hadolint/hadolint/blob/master/docs/INTEGRATION.md#pre-commit).  While the hadolint [GitHub Action](https://github.com/hadolint/hadolint/blob/master/docs/INTEGRATION.md#github-actions) is available for use it is limited to only linting for the hadolint tool, while the super-linter handles multiple language and tool scenarios.

All warnings have been addressed with either changes to the Dockerfile, inline ignore of specific rules for individual operations, or global ignores added into `.hadolint.yaml`.

A GitHub status badge has been added to visualize the state of the super-linter action.

- https://github.com/github/super-linter
  - [x] Only validate changes
  - [x] Run hadolint github action on `push` and for Pull Requests targeting `main`
    - Uses shared `.hadolint.yaml` at base of repository 
  - [x] Validate github actions
  - [x] Validate no secrets with Git Leaks
  - [x] Validate shell scripts with SHFMT
  - [x] Validate shell scripts have execute bit set
- https://github.com/pre-commit/pre-commit/
  - [x] Validate commit and push with hadolint

---

hadolint global ignores added:
  - [DL3033](https://github.com/hadolint/hadolint/wiki/DL3033)
      > Specify version with `yum install -y <package>-<version>`
    - We are NOT limiting to a specific package version at this point in time - we want the current packages
  - [DL4006](https://github.com/hadolint/hadolint/wiki/DL4006)
      > Set the SHELL option -o pipefail before RUN with a pipe in
    - SHELL uses -o pipefail, so this is a false positive
  - [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003)
    > Use WORKDIR to switch to a directory.
    - There is no need to use a `WORKDIR` operation when performing a temporary cd during a `RUN`
  - [SC2039](https://github.com/koalaman/shellcheck/wiki/SC2039)
    > In POSIX sh, something is undefined.
    - SHELL is bash, not sh - we have 'source', so this is a false positive

---

hadolint inline ignores added:
  - \# hadolint ignore=[DL3013](https://github.com/hadolint/hadolint/wiki/DL3013)
    > Pin versions in pip.
    - We are NOT limiting to a specific package version at this point in time - we want the current packages
  - \# hadolint ignore=[SC2016](https://github.com/koalaman/shellcheck/wiki/SC2016)
    > Expressions don't expand in single quotes, use double quotes for that.
    - These are either expanded by Docker or we do not want them to be expanded until runtime.
  - \# hadolint ignore=[SC2174](https://github.com/koalaman/shellcheck/wiki/SC2174)
    > When used with `-p`, `-m` only applies to the deepest directory.
    - We only need the permission of the deepest directory to be set for `${CYPRESS_CACHE_FOLDER}`

