### PR TITLE
Update publish action to pass linting and only use valid options

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -77,7 +77,6 @@ jobs:
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=edge,branch=main
             type=ref,event=branch
-            type=ref,event=push
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -37,10 +37,27 @@ jobs:
           dockerhub_token_exists="false";
           dockerhub_username_exists="false";
           dockerhub_namespace_exists="false";
-          [[ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]] && dockerhub_token_exists="true";
-          [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]] && dockerhub_username_exists="true";
-          [[ -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]] && dockerhub_namespace_exists="true";
-          [[ "true" = "${{ secrets.GITHUB_CONTAINER_PUSH_DISABLED }}" ]] && github_container_push="false";
+
+          dockerhub_token="${{ secrets.DOCKERHUB_TOKEN }}";
+          if [[ -n "${dockerhub_token}" ]]; then
+            dockerhub_token_exists="true";
+          fi
+
+          dockerhub_username="${{ secrets.DOCKERHUB_USERNAME }}";
+          if [[ -n "${dockerhub_username}" ]]; then
+            dockerhub_username_exists="true";
+          fi
+
+          dockerhub_namespace="${{ secrets.DOCKERHUB_NAMESPACE }}";
+          if [[ -n "${dockerhub_namespace}" ]]; then
+            dockerhub_namespace_exists="true";
+          fi
+
+          github_container_push_disabled="${{ secrets.GITHUB_CONTAINER_PUSH_DISABLED }}";
+          if [[ "true" = "${github_container_push_disabled}" ]]; then
+            github_container_push="false";
+          fi
+
           echo "::set-output name=dockerhub_token_exists::${dockerhub_token_exists}";
           echo "::set-output name=dockerhub_username_exists::${dockerhub_username_exists}";
           echo "::set-output name=dockerhub_namespace_exists::${dockerhub_namespace_exists}";
@@ -50,15 +67,20 @@ jobs:
         run: |
           repository_name="$(basename "${GITHUB_REPOSITORY}")";
           images=();
-          if [[ "${{ steps.from_secrets.outputs.github_container_push }}" = "true" ]];
+          github_container_push="${{ steps.from_secrets.outputs.github_container_push }}";
+          if [[ "${github_container_push}" = "true" ]];
           then
             # set GITHUB_CONTAINER_PUSH_DISABLED to a value of true to disable pushing to github container registry
             images+=("ghcr.io/${GITHUB_REPOSITORY}");
           fi
-          if [[ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]] && [[ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]] && [[ -n "${{ secrets.DOCKERHUB_NAMESPACE }}" ]];
+
+          dockerhub_token="${{ secrets.DOCKERHUB_TOKEN }}";
+          dockerhub_username="${{ secrets.DOCKERHUB_USERNAME }}";
+          dockerhub_namespace="${{ secrets.DOCKERHUB_NAMESPACE }}";
+          if [[ -n "${dockerhub_token}" ]] && [[ -n "${dockerhub_username}" ]] && [[ -n "${dockerhub_namespace}" ]];
           then
             # dockerhub repository should be the same as the github repository name, within the dockerhub namespace (organization or personal)
-            images+=("${{ secrets.DOCKERHUB_NAMESPACE }}/${repository_name}");
+            images+=("${dockerhub_namespace}/${repository_name}");
           fi
           # join the array for Docker meta job to produce image tags
           # https://github.com/crazy-max/ghaction-docker-meta#inputs


### PR DESCRIPTION
Corrects error in publish action.

- Removes `type=ref,event=push` from `docker/metadata-action@v3`.`tags`

![image](https://user-images.githubusercontent.com/4999353/142804700-1accaaa9-9030-43e5-84be-f09f566dceb3.png)

---

Corrects shellcheck linting for action

Shellcheck doesn't really understand the interpolated syntax used in GitHub Actions `${{ var }}`, so it sees literal spaces and fails any `test -n` on the variable.

![image](https://user-images.githubusercontent.com/4999353/142805800-4d0c1685-8dae-4a3e-86c4-d0793b5bfdc2.png)

