### PR TITLE
Add matrix build for targets providing tag prefix for distinct images

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,11 +11,18 @@ name: Lint Code Base
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-#############################
-# Start the job on all push #
-#############################
 on:
+  #####################################
+  # Start the job on all push to main #
+  #####################################
   push:
+    branches:
+      # pushes to main will trigger an EDGE image
+      - main
+
+  ##############################################
+  # Start the job on all pull requests to main #
+  ##############################################
   pull_request:
     branches:
       - main

--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -18,6 +18,10 @@ on:
     # at 03:00 on each Tuesday attempt to build a new image
     - cron:  '0 3 * * 2'
 
+concurrency:
+  group: publish-${{ github.head_ref }}
+  cancel-in-progress: false
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -28,6 +32,14 @@ jobs:
       # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token
       contents: read
       packages: write
+
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        target:
+          - base
+          - cypress
 
     steps:
       - name: Validate secret defined
@@ -95,6 +107,10 @@ jobs:
             org.opencontainers.image.title=Amplify Build Image
             org.opencontainers.image.description=Build Image for AWS Amplify
             org.opencontainers.image.base.name=amazonlinux:2
+          flavor: |
+            latest=auto
+            prefix=${{ matrix.target }}-
+            suffix=
           tags: |
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=edge,branch=main
@@ -110,6 +126,8 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           version: latest
+          install: true
+          use: true
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -127,13 +145,14 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push base
         uses: docker/build-push-action@v2
         with:
+          target: ${{ matrix.target }}
           builder: ${{ steps.buildx.outputs.name }}
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ env.PLATFORMS }}
+          # Setting context causes 'buildx failed with: error: failed to solve: failed to read dockerfile: open /tmp/buildkit-mountXXXXXXXXX/Dockerfile: no such file or directory'
+          # context: .
+          platforms: linux/amd64
           push: ${{ contains(fromJson('["push", "schedule"]'), github.event_name) }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Enables multiple images to be be published for `base` and `cypress` targets.  

Additional targets may be published as they are requested.