### PR TITLE
Push image on release event

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -153,7 +153,7 @@ jobs:
           # Setting context causes 'buildx failed with: error: failed to solve: failed to read dockerfile: open /tmp/buildkit-mountXXXXXXXXX/Dockerfile: no such file or directory'
           # context: .
           platforms: linux/amd64
-          push: ${{ contains(fromJson('["push", "schedule"]'), github.event_name) }}
+          push: ${{ contains(fromJson('["push", "schedule", "release"]'), github.event_name) }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha


### PR DESCRIPTION
Previous behavior was to only push to the image repository on `push` and `schedule` github events.  This behavior is understood as when a commit is pushed to the `main` branch (due to the branches filter on the push event for this workflow) and when there is a `schedule` build.

New behavior will include pushing on `release` events, which will include creating a release in the repository.